### PR TITLE
Set GPT-4o as default model for everyone

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Pardon My English is designed to assist non-native English speakers by transform
 
 # Changelog
 
+- \[2024-11-05\] GPT-4o is now the default and included in the config. All current users have been migrated to 4o too.
 - \[2024-09-15\] Llama 3.1 via Perplexity API is now a default mode for everyone!
 - \[2024-08-05\] We've updated Llama version to Llama 3.1 via Perplexity API.
 - \[2024-05-28\] We've added support for the Perplexity API, which now integrates with Llama3-70b-instruct. When selected, it adheres more closely to the initial instructions.

--- a/telegram-bot/db_client.py
+++ b/telegram-bot/db_client.py
@@ -17,8 +17,8 @@ class Account(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     user_id: str = Field(index=True, sa_type=BigInteger)  # Telegram user ID
     username: str | None
-    provider: Provider = Field(default=Provider.PERPLEXITY)
-    model: Model = Field(default=Model.LLAMA3_70B_INSTRUCT)
+    provider: Provider = Field(default=Provider.OPENAI)
+    model: Model = Field(default=Model.GPT4O)
     tokens_balance: int = Field(default=_NUM_TOKENS_DEFAULT)
     # Whether the user is a friend of the bot owner.
     # This is used to give the user an unlimited token balance.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- GPT-4o is now the default model for all users, enhancing performance and capabilities.
	- Added instructions for running the app locally using Streamlit, including setup for the Groq API key.

- **Bug Fixes**
	- Updated default account settings to use OpenAI as the provider and GPT-4o as the model, ensuring new accounts are configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->